### PR TITLE
Changed error message when stream is closed.

### DIFF
--- a/src/main/java/io/teknek/farsandra/StreamReader.java
+++ b/src/main/java/io/teknek/farsandra/StreamReader.java
@@ -31,7 +31,7 @@ public class StreamReader implements Runnable {
         }
       }
     } catch (IOException e) {
-      e.printStackTrace();
+      System.out.println("Connection to Cassandra closed: " + e.getMessage());
     } 
   }
   


### PR DESCRIPTION
I'd really like to see this change implemented.

I'm using farsandra for unit-tests, where I start and stop Cassandra multiple times. It is pretty irritating to see the stack trace everytime Cassandra shuts down.

If you'd like to see the stack trace, I could create another pull request where you simply have to set a flag to disable the stack trace.
