### PR TITLE
Added methods to handle process termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Putting listeners on the output and error streams
       }
     });
 
+Adding an handler to manage process termination
+==========
+
+    fs.getManager().addProcessHandler(new ProcessHandler() {
+        @Override
+        public void handleTermination(int exitValue) {
+            System.out.println("Cassandra terminated with exit value: " + exitValue);
+            started.countDown();
+        }
+    });
+
 Puttingit all together
 ==========
 
@@ -89,6 +100,13 @@ Puttingit all together
       public void handleLine(String line) {
         System.out.println("err "+line);
       }
+    });
+    fs.getManager().addProcessHandler(new ProcessHandler() {
+        @Override
+        public void handleTermination(int exitValue) {
+            System.out.println("Cassandra terminated with exit value: " + exitValue);
+            started.countDown();
+        }
     });
     fs.start();
     started.await();

--- a/src/main/java/io/teknek/farsandra/Farsandra.java
+++ b/src/main/java/io/teknek/farsandra/Farsandra.java
@@ -14,7 +14,6 @@ import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -22,7 +21,6 @@ import java.util.TreeMap;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-
 import org.apache.log4j.Logger;
 
 public class Farsandra {

--- a/src/main/java/io/teknek/farsandra/ProcessHandler.java
+++ b/src/main/java/io/teknek/farsandra/ProcessHandler.java
@@ -1,0 +1,5 @@
+package io.teknek.farsandra;
+
+public interface ProcessHandler {
+    public void handleTermination(int exitValue);
+}

--- a/src/test/java/io/teknek/farsandra/UnflushedJoinTest.java
+++ b/src/test/java/io/teknek/farsandra/UnflushedJoinTest.java
@@ -1,5 +1,7 @@
 package io.teknek.farsandra;
 
+import static org.junit.Assert.assertTrue;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
@@ -45,8 +47,16 @@ public class UnflushedJoinTest {
         }
       }
     });
+    fs.getManager().addProcessHandler(new ProcessHandler() { 
+      @Override
+      public void handleTermination(int exitValue) {
+        System.out.println("Cassandra terminated with exit value: " + exitValue);
+        started.countDown();
+      }
+    });
     fs.start();
     started.await();
+    assertTrue("Cassandra is not running", fs.getManager().isRunning());
     return fs;
   }
  


### PR DESCRIPTION
After calling the method Farsandra#start, currently it is impossible to determine if the process terminated because of an error or it is still running.
Moreover, when using the CountDownLatch, if the process terminates (or crashes) immediately after calling the start method, the await() method blocks forever.

I've exposed a few methods to determine if the process is running, namely isRunning, getExitValue and waitFor.
Moreover I'd added a method to add a process termination handler, in order to be able to decrement the CountDownLatch if the process terminates or crashes, and avoiding blocking forever.
