### PR TITLE
Upgrade Cassandra-thrift to version 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.apache.cassandra</groupId>
 			<artifactId>cassandra-thrift</artifactId>
-			<version>2.2.0</version>
+			<version>2.2.1</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Hi Edward.

This PR updates Cassandra-thrift to version 2.2.1

I'll wait for you to merge the PR. Next week I'll merge by myself if you can't :-)

Andrea