### PR TITLE
Support Cassandra versions after 2.0.x

### DIFF
--- a/farsandra-core/src/test/java/io/teknek/farsandra/CompareAndSwapTest.java
+++ b/farsandra-core/src/test/java/io/teknek/farsandra/CompareAndSwapTest.java
@@ -24,9 +24,9 @@ public class CompareAndSwapTest {
   
   @Test
   public void threeNodeTest() throws Exception {
-    fs1 = UnflushedJoinTest.startInstance("2.0.4", "target/3_1", "127.0.0.1", "127.0.0.1", 9999);
-    fs2 = UnflushedJoinTest.startInstance("2.0.4", "target/3_2", "127.0.0.2", "127.0.0.1", 9998);    
-    fs3 = UnflushedJoinTest.startInstance("2.0.4", "target/3_3", "127.0.0.3", "127.0.0.1", 9997);
+    fs1 = UnflushedJoinTest.startInstance("2.2.4", "target/3_1", "127.0.0.1", "127.0.0.1", 9999);
+    fs2 = UnflushedJoinTest.startInstance("2.2.4", "target/3_2", "127.0.0.2", "127.0.0.1", 9998);    
+    fs3 = UnflushedJoinTest.startInstance("2.2.4", "target/3_3", "127.0.0.3", "127.0.0.1", 9997);
     
     FramedConnWrapper wrap = new FramedConnWrapper("127.0.0.1", 9160);
     String ks = "CREATE KEYSPACE test "

--- a/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandra.java
+++ b/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandra.java
@@ -42,7 +42,7 @@ public class TestFarsandra {
   
   @Test
   public void testShutdownWithLatch() throws InterruptedException {
-    fs.withVersion("2.0.4");
+    fs.withVersion("2.2.4");
     fs.withCleanInstanceOnStart(true);
     fs.withInstanceName("target/3_1");
     fs.withCreateConfigurationFiles(true);
@@ -51,7 +51,7 @@ public class TestFarsandra {
     fs.withJmxPort(9999);   
     fs.appendLineToYaml("#this means nothing");
     fs.appendLinesToEnv("#this also does nothing");
-    fs.withEnvReplacement("#MALLOC_ARENA_MAX=4", "#MALLOC_ARENA_MAX=wombat");
+    fs.withEnvReplacement("# Per-thread stack size.", "# Per-thread stack size. wombat");
     fs.withYamlReplacement("# NOTE:", "# deNOTE:");
     final CountDownLatch started = new CountDownLatch(1);
     fs.getManager().addOutLineHandler( new LineHandler(){
@@ -82,7 +82,7 @@ public class TestFarsandra {
   public void threeNodeTest() throws InterruptedException, InvalidRequestException, UnavailableException, TimedOutException, SchemaDisagreementException, TException {
     Farsandra fs = new Farsandra();
     {
-    fs.withVersion("2.0.4");
+    fs.withVersion("2.2.4");
     fs.withCleanInstanceOnStart(true);
     fs.withInstanceName("target/3_1");
     fs.withCreateConfigurationFiles(true);
@@ -116,7 +116,7 @@ public class TestFarsandra {
     Farsandra fs2 = new Farsandra();
     {
 
-      fs2.withVersion("2.0.4");
+      fs2.withVersion("2.2.4");
       fs2.withCleanInstanceOnStart(true);
       fs2.withInstanceName("target/3_2");
       fs2.withCreateConfigurationFiles(true);
@@ -151,7 +151,7 @@ public class TestFarsandra {
     Farsandra fs3 = new Farsandra();
     {
 
-      fs3.withVersion("2.0.4");
+      fs3.withVersion("2.2.4");
       fs3.withCleanInstanceOnStart(true);
       fs3.withInstanceName("target/3_3");
       fs3.withCreateConfigurationFiles(true);
@@ -222,7 +222,7 @@ public class TestFarsandra {
   
   @Test
   public void simpleOtherTest() throws InterruptedException{
-    fs.withVersion("2.0.3");
+    fs.withVersion("2.2.3");
     fs.withCleanInstanceOnStart(true);
     fs.withInstanceName("target/1");
     fs.withCreateConfigurationFiles(true);
@@ -266,7 +266,7 @@ public class TestFarsandra {
   
   @Test
   public void simpleTest() throws InterruptedException {
-    fs.withVersion("2.0.4");
+    fs.withVersion("2.2.4");
     fs.withCleanInstanceOnStart(true);
     fs.withInstanceName("target/1");
     fs.withCreateConfigurationFiles(true);

--- a/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandraWithCustomConfig.java
+++ b/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandraWithCustomConfig.java
@@ -42,7 +42,7 @@ public class TestFarsandraWithCustomConfig {
   
   @Test
   public void testShutdownWithLatch() throws InterruptedException {
-    fs.withVersion("2.0.4");
+    fs.withVersion("2.2.4");
     fs.withCleanInstanceOnStart(true);
     fs.withInstanceName("target/3_1");
     fs.withCreateConfigurationFiles(true);
@@ -51,7 +51,7 @@ public class TestFarsandraWithCustomConfig {
     fs.withJmxPort(9999);   
     fs.appendLineToYaml("#this means nothing");
     fs.appendLinesToEnv("#this also does nothing");
-    fs.withEnvReplacement("#MALLOC_ARENA_MAX=4", "#MALLOC_ARENA_MAX=wombat");
+    fs.withEnvReplacement("# Per-thread stack size.", "# Per-thread stack size. wombat");
     fs.withYamlReplacement("# NOTE:", "# deNOTE:");
     final CountDownLatch started = new CountDownLatch(1);
     fs.getManager().addOutLineHandler( new LineHandler(){
@@ -79,7 +79,7 @@ public class TestFarsandraWithCustomConfig {
   
   @Test
   public void simpleTest() throws InterruptedException {
-    fs.withVersion("2.0.4");
+    fs.withVersion("2.2.4");
     fs.withCleanInstanceOnStart(true);
     fs.withInstanceName("target/1");
     fs.withCreateConfigurationFiles(true);

--- a/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandraWithDefaultConfig.java
+++ b/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandraWithDefaultConfig.java
@@ -42,7 +42,7 @@ public class TestFarsandraWithDefaultConfig {
   
   @Test
   public void testShutdownWithLatch() throws InterruptedException {
-    fs.withVersion("2.0.4");
+    fs.withVersion("2.2.4");
     fs.withCleanInstanceOnStart(true);
     fs.withInstanceName("target/3_1");
     fs.withCreateConfigurationFiles(true);
@@ -51,7 +51,7 @@ public class TestFarsandraWithDefaultConfig {
     fs.withJmxPort(9999);   
     fs.appendLineToYaml("#this means nothing");
     fs.appendLinesToEnv("#this also does nothing");
-    fs.withEnvReplacement("#MALLOC_ARENA_MAX=4", "#MALLOC_ARENA_MAX=wombat");
+    fs.withEnvReplacement("# Per-thread stack size.", "# Per-thread stack size. wombat");
     fs.withYamlReplacement("# NOTE:", "# deNOTE:");
     final CountDownLatch started = new CountDownLatch(1);
     fs.getManager().addOutLineHandler( new LineHandler(){
@@ -79,7 +79,7 @@ public class TestFarsandraWithDefaultConfig {
   
   @Test
   public void simpleTest() throws InterruptedException {
-    fs.withVersion("2.0.4");
+    fs.withVersion("2.2.4");
     fs.withCleanInstanceOnStart(true);
     fs.withInstanceName("target/1");
     fs.withCreateConfigurationFiles(true);

--- a/farsandra-core/src/test/java/io/teknek/farsandra/UnflushedJoinTest.java
+++ b/farsandra-core/src/test/java/io/teknek/farsandra/UnflushedJoinTest.java
@@ -74,9 +74,9 @@ public class UnflushedJoinTest {
   
   @Test
   public void threeNodeTest() throws Exception {
-    fs = startInstance("2.0.4", "target/3_1", "127.0.0.1", "127.0.0.1", 9999);
-    fs2 = startInstance("2.0.4", "target/3_2", "127.0.0.2", "127.0.0.1", 9998);    
-    fs3 = startInstance("2.0.4", "target/3_3", "127.0.0.3", "127.0.0.1", 9997);
+    fs = startInstance("2.2.4", "target/3_1", "127.0.0.1", "127.0.0.1", 9999);
+    fs2 = startInstance("2.2.4", "target/3_2", "127.0.0.2", "127.0.0.1", 9998);    
+    fs3 = startInstance("2.2.4", "target/3_3", "127.0.0.3", "127.0.0.1", 9997);
     Thread.sleep(30000);
     FramedConnWrapper wrap = new FramedConnWrapper("127.0.0.1", 9160);
     String ks = "CREATE KEYSPACE test "
@@ -101,7 +101,7 @@ public class UnflushedJoinTest {
     assertAllThere("127.0.0.1"); 
 
     System.out.println("added");
-    fs4 = startInstance("2.0.4", "target/3_4", "127.0.0.4", "127.0.0.1", 9996);
+    fs4 = startInstance("2.2.4", "target/3_4", "127.0.0.4", "127.0.0.1", 9996);
     Thread.sleep(40000);
     assertAllThere("127.0.0.4");
   }


### PR DESCRIPTION
I took a stab at a fix for #21. With this commit, the tests pass with 2.0, 2.1, 2.2 and 3.0. I also rev'd the version used in the tests to 2.2.4.