### PR TITLE
Handle YAML replacement using SnakeYAML parsing/serialization instead of string manipulation.

### DIFF
--- a/farsandra-core/pom.xml
+++ b/farsandra-core/pom.xml
@@ -63,6 +63,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.16</version>
+    </dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>

--- a/farsandra-core/src/main/java/io/teknek/farsandra/Farsandra.java
+++ b/farsandra-core/src/main/java/io/teknek/farsandra/Farsandra.java
@@ -1,13 +1,12 @@
 package io.teknek.farsandra;
 
-import io.teknek.farsandra.config.ConfigHolder;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,6 +15,7 @@ import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -26,6 +26,9 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.log4j.Logger;
+import org.yaml.snakeyaml.Yaml;
+
+import io.teknek.farsandra.config.ConfigHolder;
 
 public class Farsandra {
 
@@ -49,7 +52,7 @@ public class Farsandra {
   private Map<String ,String> envReplacements;
   private Map<String, String> yamlReplacements;
   private ConfigHolder configHolder;
-  
+
   public Farsandra(){
     manager = new CForgroundManager();
     yamlLinesToAppend = new ArrayList<String>();
@@ -57,7 +60,7 @@ public class Farsandra {
     envReplacements = new TreeMap<String, String>();
     yamlReplacements = new TreeMap<String, String>();
   }
-  
+
   public Farsandra(boolean readProps){
     manager = new CForgroundManager();
     yamlLinesToAppend = new ArrayList<String>();
@@ -66,8 +69,8 @@ public class Farsandra {
     yamlReplacements = new TreeMap<String, String>();
     if (readProps == true) configHolder = new ConfigHolder();
   }
-  
-  
+
+
   public Farsandra(String configFile){
     manager = new CForgroundManager();
     yamlLinesToAppend = new ArrayList<String>();
@@ -76,22 +79,22 @@ public class Farsandra {
     yamlReplacements = new TreeMap<String, String>();
     configHolder = new ConfigHolder(configFile);
    }
-  
+
   public Farsandra withCleanInstanceOnStart(boolean start){
     this.cleanInstanceOnStart = start;
     return this;
   }
-  
+
   public Farsandra withSeeds(List<String> seeds){
     this.seeds = seeds;
     return this;
   }
-  
+
   public List<String> appendLinesToEnv(String line){
     envLinesToAppend.add(line);
     return envLinesToAppend;
   }
-  
+
   /**
    * Add line to the bottom of yaml. Does not check if line already exists
    * @param line a line to add
@@ -110,10 +113,10 @@ public class Farsandra {
     this.version = version;
     return this;
   }
-  public Farsandra withYamlReplacement(String match, String replace){
-    this.yamlReplacements.put(match, replace);
-    return this;
-  }
+//  public Farsandra withYamlReplacement(String match, String replace){
+//    this.yamlReplacements.put(match, replace);
+//    return this;
+//  }
   public Farsandra withEnvReplacement(String match,String replace){
     this.envReplacements.put(match, replace);
     return this;
@@ -154,7 +157,7 @@ public class Farsandra {
       this.host = host;
       return this;
   }
-  
+
   /**
    * Sets the instance name. This will also be the data directory where the instance is found
    * @param name
@@ -164,22 +167,22 @@ public class Farsandra {
     this.instanceName = name;
     return this;
   }
-  
+
   public Farsandra withCreateConfigurationFiles(boolean write){
     this.createConfigurationFiles = write;
     return this;
   }
-  
+
   public Farsandra withJavaHome(String javaHome){
     this.javaHome = javaHome;
     return this;
   }
-  
+
   public Farsandra withJmxPort(int jmxPort){
     this.jmxPort = jmxPort;
     return this;
   }
-  
+
   public static void uncompressTarGZ(File tarFile, File dest) throws IOException {
     // http://stackoverflow.com/questions/11431143/how-to-untar-a-tar-file-using-apache-commons/14211580#14211580
     dest.mkdir();
@@ -209,7 +212,7 @@ public class Farsandra {
     }
     tarIn.close();
   }
-  
+
   public void download(String version, File location){
     LOGGER.info("Version of Cassandra not found locally. Attempting to fetch it from cloud");
     try {
@@ -237,7 +240,7 @@ public class Farsandra {
       throw new RuntimeException(e);
     }
   }
-  
+
   /**
    * Starts the instance of cassandra in a non-blocking manner. Use line handler and other methods
    * to detect when startup is complete.
@@ -266,7 +269,7 @@ public class Farsandra {
     } else {
       gunzip = this.getConfigHolder().getProperties().getProperty("cassandra.package.name.prefix")+version+this.getConfigHolder().getProperties().getProperty("cassandra.package.name.suffix");
     }
-    File archive = new File(farsandra, gunzip); 
+    File archive = new File(farsandra, gunzip);
     if (!archive.exists()){
       download(version,farsandra);
       try {
@@ -293,8 +296,8 @@ public class Farsandra {
         delete(instanceBase);
       }
     }
-    
-    if (createConfigurationFiles){ 
+
+    if (createConfigurationFiles){
       instanceBase.mkdir();
       File instanceConf;
       File instanceLog;
@@ -327,94 +330,58 @@ public class Farsandra {
         binaryConf = new File(cRoot, this.getConfigHolder().getProperties().getProperty("farsandra.conf.dir"));
         cassandraYaml = new File(binaryConf, this.getConfigHolder().getProperties().getProperty("cassandra.config.file.name"));
       }
-      
+
       setUpLoggingConf(instanceConf, instanceLog);
       makeCassandraEnv(binaryConf, instanceConf);
 
-      List<String> lines;
       try {
-        lines = Files.readAllLines(cassandraYaml.toPath(), Charset.defaultCharset());
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-      lines = replaceHost(lines);
-      try {
-        lines = replaceThisWithThatExpectNMatch(lines,
-                "    - /var/lib/cassandra/data",
-                "    - " + this.instanceName + "/data/data" , 1);
-      } catch (RuntimeException ex) {
-        lines = replaceThisWithThatExpectNMatch(lines,
-          "# data_file_directories:",
-          "data_file_directories:" , 1);
-        lines = replaceThisWithThatExpectNMatch(lines,
-          "#     - /var/lib/cassandra/data",
-          "    - " + this.instanceName + "/data/data" , 1);
-      }
-      lines = replaceThisWithThatExpectNMatch(lines,
-              "listen_address: localhost",
-              "listen_address: " +host , 1);
-      try {
-        lines = replaceThisWithThatExpectNMatch(lines,
-                "commitlog_directory: /var/lib/cassandra/commitlog",
-                "commitlog_directory: " + this.instanceName + "/data/commitlog" , 1 );
-      } catch (RuntimeException ex) {
-        lines = replaceThisWithThatExpectNMatch(lines,
-          "# commitlog_directory: /var/lib/cassandra/commitlog",
-          "commitlog_directory: " + this.instanceName + "/data/commitlog" , 1 );
-      }
-      try {
-        lines = replaceThisWithThatExpectNMatch(lines,
-                "saved_caches_directory: /var/lib/cassandra/saved_caches",
-                "saved_caches_directory: " + this.instanceName + "/data/saved_caches", 1);
-      } catch (RuntimeException ex) {
-        lines = replaceThisWithThatExpectNMatch(lines,
-          "# saved_caches_directory: /var/lib/cassandra/saved_caches",
-          "saved_caches_directory: " + this.instanceName + "/data/saved_caches", 1);
-      }
-      try {
-        lines = replaceThisWithThatExpectNMatch(lines,
-          "start_rpc: false",
-          "start_rpc: true", 1);
-      } catch (RuntimeException ex) {
-        // Only needed for C* 2.2+
-      }
-      if (storagePort != null){
-        lines = replaceThisWithThatExpectNMatch(lines, "storage_port: 7000", "storage_port: "+storagePort, 1 );
-      }
-      if (rpcPort != null){
-        lines = replaceThisWithThatExpectNMatch(lines, "rpc_port: 9160", "rpc_port: " + rpcPort, 1);
-      }
-      if (nativeTransportPort != null){
-        lines = replaceThisWithThatExpectNMatch(lines, "native_transport_port: 9042", "native_transport_port: "+nativeTransportPort, 1 );
-      }
-      if (seeds != null) {
-        lines = replaceThisWithThatExpectNMatch(lines, "          - seeds: \"127.0.0.1\"",
-                "         - seeds: \"" + seeds.get(0) + "\"", 1);
-      }
-      for (Map.Entry<String,String> entry: yamlReplacements.entrySet()){
-        lines = replaceThisWithThatExpectNMatch(lines, entry.getKey(), entry.getValue(), 1);
-      }
-      lines = yamlLinesToAppend(lines);
-      File instanceConfToWrite;
-      if (configHolder == null){
-        instanceConfToWrite = new File(instanceConf, "cassandra.yaml");
-      } else {
-    	instanceConfToWrite = new File(instanceConf, this.getConfigHolder().getProperties().getProperty("cassandra.config.file.name"));
-      }
-      try (BufferedWriter bw = new BufferedWriter(new FileWriter(instanceConfToWrite))){
-        for (String s: lines){
-          bw.write(s);
+        Yaml yaml = new Yaml();
+        @SuppressWarnings("unchecked")
+        CassandraYaml cyaml = new CassandraYaml((LinkedHashMap<String,Object>)yaml.load(new FileReader(cassandraYaml)));
+        cyaml.setRpc_address(host);
+        ArrayList<String> dfd = new ArrayList<String>();
+        dfd.add(this.instanceName + "/data/data");
+        cyaml.setData_file_directories(dfd);
+        cyaml.setListen_address(host);
+        cyaml.setCommitlog_directory(this.instanceName + "/data/commitlog");
+        cyaml.setSaved_caches_directory(this.instanceName + "/data/saved_caches");
+        cyaml.setStart_rpc(true);
+        if (storagePort != null){
+          cyaml.setStorage_port(storagePort);
+        }
+        if (rpcPort != null){
+          cyaml.setRpc_port(rpcPort);
+        }
+        if (nativeTransportPort != null){
+          cyaml.setNative_transport_port(nativeTransportPort);
+        }
+        if (seeds != null) {
+          cyaml.getSeed_provider().get(0).getParameters().get(0).setSeeds(seeds.get(0));
+        }
+//        for (Map.Entry<String,String> entry: yamlReplacements.entrySet()){
+//          lines = replaceThisWithThatExpectNMatch(lines, entry.getKey(), entry.getValue(), 1);
+//        }
+        File instanceConfToWrite;
+        if (configHolder == null){
+          instanceConfToWrite = new File(instanceConf, "cassandra.yaml");
+        } else {
+          instanceConfToWrite = new File(instanceConf, this.getConfigHolder().getProperties().getProperty("cassandra.config.file.name"));
+        }
+        BufferedWriter bw = new BufferedWriter(new FileWriter(instanceConfToWrite));
+        yaml.dump(cyaml.getMap(), bw);
+        for (String line : yamlLinesToAppend) {
+          bw.write(line);
           bw.newLine();
         }
       } catch (IOException e) {
         throw new RuntimeException(e);
-      } 
+      }
     }
      //  /bin/bash -c "env - X=5 y=2 sh xandy.sh"
     //#   JVM_OPTS -- Additional arguments to the JVM for heap size, etc
     //#   CASSANDRA_CONF -- Directory containing Cassandra configuration files.
     File cstart = new File(new File( cRoot, "bin"),"cassandra");
-    
+
     /*String launch = "/bin/bash -c \"/usr/bin/env - CASSANDRA_CONF=" + instanceConf.getAbsolutePath() +" JAVA_HOME="+
             "/usr/java/jdk1.7.0_45 "
             + cstart.getAbsolutePath().toString() + " -f \""; */
@@ -428,25 +395,26 @@ public class Farsandra {
     //command = command + " JAVA_HOME=" + "/usr/java/jdk1.7.0_45 ";
     command = command + buildJavaHome() + " ";
     command = command + " /bin/bash " + cstart.getAbsolutePath().toString() + " -f ";
-    String [] launchArray = new String [] { 
-            "/bin/bash" , 
-            "-c" , 
+    String [] launchArray = new String [] {
+            "/bin/bash" ,
+            "-c" ,
              command };
     manager.setLaunchArray(launchArray);
     manager.go();
   }
 
 
+
   /**
    * Replaces the default file path of the system log.
    * Cassandra comes with a log4j configuration that assumes, by default, there's a /var/log/cassandra directory
-   * with R/W permissions. 
-   * While in a regular installation you have the chance to edit that file before starting Cassandra, 
-   * with Farsandra things are different: the instance is automatically started so if you don't have that directory 
+   * with R/W permissions.
+   * While in a regular installation you have the chance to edit that file before starting Cassandra,
+   * with Farsandra things are different: the instance is automatically started so if you don't have that directory
    * (or you didn't set those required permissions), an exception is printed out and the system.log is never created.
    * This method makes sure the default path of the logging file is replaced with a path located under the Farsandra instance
    * directory ($FARSANDRA_INSTANCE_DIR/log/system.log).
-   * 
+   *
    * @param instanceConfDirectory the instance "conf" directory.
    * @param instanceLogDirectory the instance "log" directory.
    */
@@ -513,20 +481,13 @@ public class Farsandra {
     }
   }
 
-private List<String> yamlLinesToAppend(List<String> input){
-    List<String> results = new ArrayList<String>();
-    results.addAll(input);
-    results.addAll(yamlLinesToAppend);
-    return results;
-  }
-  
   private List<String> envLinesToAppend(List<String> input){
     List<String> results = new ArrayList<String>();
     results.addAll( input);
     results.addAll(this.envLinesToAppend);
     return results;
   }
-  
+
   /**
    * Builds the cassandra-env.sh replacing stuff along the way
    * @param binaryConf directory of downloaded conf
@@ -554,7 +515,7 @@ private List<String> yamlLinesToAppend(List<String> input){
             + this.jmxPort + "\"", 1);
     }
     if (maxHeapSize !=null){
-      lines = replaceThisWithThatExpectNMatch(lines, "#MAX_HEAP_SIZE=\"4G\"", 
+      lines = replaceThisWithThatExpectNMatch(lines, "#MAX_HEAP_SIZE=\"4G\"",
               "MAX_HEAP_SIZE=\""+this.maxHeapSize+"\"", 1);
     }
     if (heapNewSize != null) {
@@ -571,7 +532,7 @@ private List<String> yamlLinesToAppend(List<String> input){
       throw new RuntimeException(e);
     }
   }
-  
+
   public String buildJavaHome() {
     if (this.javaHome != null) {
       return " JAVA_HOME=" + this.javaHome;
@@ -590,7 +551,7 @@ private List<String> yamlLinesToAppend(List<String> input){
     if (!f.delete())
       throw new RuntimeException("Failed to delete file: " + f);
   }
-  
+
   public List<String> replaceThisWithThatExpectNMatch(List<String> lines, String match, String replace, int expectedMatches){
     List<String> result = new ArrayList<String>();
     int replaced = 0;
@@ -608,8 +569,8 @@ private List<String> yamlLinesToAppend(List<String> input){
     }
     return result;
   }
-  
- 
+
+
   public List<String> replaceHost(List<String> lines){
     List<String> result = new ArrayList<String>();
     int replaced = 0;
@@ -627,12 +588,12 @@ private List<String> yamlLinesToAppend(List<String> input){
     }
     return result;
   }
-  
+
   public static void copyConfToInstanceDir(File cassandraBinaryRoot, File instanceConf, ConfigHolder configHolder){
     if (configHolder == null){
       File binaryConf = new File(cassandraBinaryRoot, "conf");
-      for (File file: binaryConf.listFiles()){  
-        if (!file.getName().equals("cassandra.yaml") || 
+      for (File file: binaryConf.listFiles()){
+        if (!file.getName().equals("cassandra.yaml") ||
               !file.getName().equals("cassandra-env.sh")){
           try {
             Files.copy(file.toPath(), new File(instanceConf, file.getName()).toPath() );
@@ -640,11 +601,11 @@ private List<String> yamlLinesToAppend(List<String> input){
             throw new RuntimeException(e);
           }
         }
-      }   	
+      }
     } else {
       File binaryConf = new File(cassandraBinaryRoot, configHolder.getProperties().getProperty("farsandra.conf.dir"));
-      for (File file: binaryConf.listFiles()){  
-        if (!file.getName().equals(configHolder.getProperties().getProperty("cassandra.config.file.name")) || 
+      for (File file: binaryConf.listFiles()){
+        if (!file.getName().equals(configHolder.getProperties().getProperty("cassandra.config.file.name")) ||
               !file.getName().equals(configHolder.getProperties().getProperty("cassandra.environment.file.name"))){
           try {
             Files.copy(file.toPath(), new File(instanceConf, file.getName()).toPath() );
@@ -655,7 +616,7 @@ private List<String> yamlLinesToAppend(List<String> input){
       }
     }
   }
-    
+
   public CForgroundManager getManager() {
     return manager;
   }
@@ -670,5 +631,131 @@ private List<String> yamlLinesToAppend(List<String> input){
 
   public void setConfigHolder(ConfigHolder configHolder) {
 	this.configHolder = configHolder;
-  } 
+  }
+  @SuppressWarnings("unchecked")
+  public static class CassandraYaml {
+    private LinkedHashMap<String, Object> map;
+
+    public CassandraYaml(LinkedHashMap<String, Object> map) {
+      this.map = map;
+    }
+    public LinkedHashMap<String, Object> getMap() {
+      return map;
+    }
+    public String getRpc_address() {
+      return (String)map.get("rpc_address");
+    }
+    public void setRpc_address(String rpc_address) {
+      map.put("rpc_address", rpc_address);
+    }
+    public ArrayList<String> getData_file_directories() {
+      return (ArrayList<String>)map.get("data_file_directories");
+    }
+    public void setData_file_directories(ArrayList<String> data_file_directories) {
+      map.put("data_file_directories", data_file_directories);
+    }
+    public String getListen_address() {
+      return (String)map.get("listen_address");
+    }
+    public void setListen_address(String listen_address) {
+      map.put("listen_address", listen_address);
+    }
+    public String getCommitlog_directory() {
+      return (String)map.get("commitlog_directory");
+    }
+    public void setCommitlog_directory(String commitlog_directory) {
+      map.put("commitlog_directory", commitlog_directory);
+    }
+    public String getSaved_caches_directory() {
+      return (String)map.get("saved_caches_directory");
+    }
+    public void setSaved_caches_directory(String saved_caches_directory) {
+      map.put("saved_caches_directory", saved_caches_directory);
+    }
+    public Boolean getStart_rpc() {
+      return (Boolean)map.get("start_rpc");
+    }
+    public void setStart_rpc(Boolean start_rpc) {
+      map.put("start_rpc", start_rpc);
+    }
+    public Integer getStorage_port() {
+      return (Integer)map.get("storage_port");
+    }
+    public void setStorage_port(Integer storage_port) {
+      map.put("storage_port", storage_port);
+    }
+    public Integer getRpc_port() {
+      return (Integer)map.get("rpc_port");
+    }
+    public void setRpc_port(Integer rpc_port) {
+      map.put("rpc_port", rpc_port);
+    }
+    public Integer getNative_transport_port() {
+      return (Integer)map.get("native_transport_port");
+    }
+    public void setNative_transport_port(Integer native_transport_port) {
+      map.put("native_transport_port", native_transport_port);
+    }
+    public ArrayList<SeedProvider> getSeed_provider() {
+      ArrayList<SeedProvider> ret = new ArrayList<SeedProvider>();
+      ArrayList<LinkedHashMap<String,Object>> sps = ((ArrayList<LinkedHashMap<String,Object>>)map.get("seed_provider"));
+      for (LinkedHashMap<String,Object> sp : sps) {
+        ret.add(new SeedProvider(sp));
+      }
+      return ret;
+    }
+//    public void setSeed_provider(ArrayList<SeedProvider> seed_provider) {
+//    }
+    public void replace(String key, Object match, Object replace) {
+      if (!map.containsKey(key)) {
+        throw new RuntimeException("Unable to find key ('" + key + "'). "
+          +"Likely that farsandra does not understand this version of configuration file. ");
+      }
+      if (!map.get(key).equals(match)) {
+        throw new RuntimeException("Key ('" + key + "')'s value doesn't match expected value ('" + match + "'). "
+          +"Likely that farsandra does not understand this version of configuration file. ");
+      }
+      map.put(key, replace);
+    }
+    static class SeedProvider {
+      LinkedHashMap<String, Object> map;
+      public SeedProvider(LinkedHashMap<String, Object> map) {
+        this.map = map;
+      }
+      public LinkedHashMap<String, Object> getMap() {
+        return map;
+      }
+      public String getClass_name() {
+        return (String)map.get("class_name");
+      }
+      public void setClass_name(String class_name) {
+        map.put("class_name", class_name);
+      }
+      public ArrayList<Parameter> getParameters() {
+        ArrayList<Parameter> ret = new ArrayList<Parameter>();
+        ArrayList<LinkedHashMap<String,Object>> ps = ((ArrayList<LinkedHashMap<String,Object>>)map.get("parameters"));
+        for (LinkedHashMap<String,Object> p : ps) {
+          ret.add(new Parameter(p));
+        }
+        return ret;
+
+      }
+      static class Parameter {
+        LinkedHashMap<String, Object> map;
+
+        public Parameter(LinkedHashMap<String, Object> map) {
+          this.map = map;
+        }
+        public LinkedHashMap<String, Object> getMap() {
+          return map;
+        }
+        public String getSeeds() {
+          return (String)map.get("seeds");
+        }
+        public void setSeeds(String seeds) {
+          map.put("seeds", seeds);
+        }
+      }
+    }
+  }
 }

--- a/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandra.java
+++ b/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandra.java
@@ -52,7 +52,7 @@ public class TestFarsandra {
     fs.appendLineToYaml("#this means nothing");
     fs.appendLinesToEnv("#this also does nothing");
     fs.withEnvReplacement("# Per-thread stack size.", "# Per-thread stack size. wombat");
-    fs.withYamlReplacement("# NOTE:", "# deNOTE:");
+//    fs.withYamlReplacement("# NOTE:", "# deNOTE:");
     final CountDownLatch started = new CountDownLatch(1);
     fs.getManager().addOutLineHandler( new LineHandler(){
         @Override

--- a/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandraWithCustomConfig.java
+++ b/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandraWithCustomConfig.java
@@ -52,7 +52,7 @@ public class TestFarsandraWithCustomConfig {
     fs.appendLineToYaml("#this means nothing");
     fs.appendLinesToEnv("#this also does nothing");
     fs.withEnvReplacement("# Per-thread stack size.", "# Per-thread stack size. wombat");
-    fs.withYamlReplacement("# NOTE:", "# deNOTE:");
+//    fs.withYamlReplacement("# NOTE:", "# deNOTE:");
     final CountDownLatch started = new CountDownLatch(1);
     fs.getManager().addOutLineHandler( new LineHandler(){
         @Override

--- a/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandraWithDefaultConfig.java
+++ b/farsandra-core/src/test/java/io/teknek/farsandra/TestFarsandraWithDefaultConfig.java
@@ -52,7 +52,7 @@ public class TestFarsandraWithDefaultConfig {
     fs.appendLineToYaml("#this means nothing");
     fs.appendLinesToEnv("#this also does nothing");
     fs.withEnvReplacement("# Per-thread stack size.", "# Per-thread stack size. wombat");
-    fs.withYamlReplacement("# NOTE:", "# deNOTE:");
+//    fs.withYamlReplacement("# NOTE:", "# deNOTE:");
     final CountDownLatch started = new CountDownLatch(1);
     fs.getManager().addOutLineHandler( new LineHandler(){
         @Override

--- a/farsandra-maven-plugin/src/main/java/io/teknek/farsandra/maven/plugin/goals/Start.java
+++ b/farsandra-maven-plugin/src/main/java/io/teknek/farsandra/maven/plugin/goals/Start.java
@@ -90,9 +90,9 @@ public class Start extends AbstractMojo {
 			.withCleanInstanceOnStart(cleanInstanceOnStart)
 			.withCreateConfigurationFiles(createConfigurationFiles);
 
-		for (final Map.Entry<String, String> entry : yamlReplacements.entrySet()) {
-			farsandra.withYamlReplacement(entry.getKey(), entry.getValue());
-		}
+//		for (final Map.Entry<String, String> entry : yamlReplacements.entrySet()) {
+//			farsandra.withYamlReplacement(entry.getKey(), entry.getValue());
+//		}
 
 		for (final String line : additionalYamlLines) {
 			farsandra.appendLineToYaml(line);


### PR DESCRIPTION
Handle YAML replacement using SnakeYAML parsing/serialization instead of string manipulation.

So I was thinking about the discussion on #22. I wondered if the issues around supporting multiple versions could be reduced by parsing the YAML and manipulating the parsed tree, rather than doing text replacement. This is the result.

I used SnakeYAML to parse `cassandra.yaml` and built a little object model (see [here](https://github.com/jancona/farsandra/blob/5c65a9a21e657097e32be0f750637a43f174828b/farsandra-core/src/main/java/io/teknek/farsandra/Farsandra.java#L636)). It's backed by the generic SnakeYAML parse tree, with custom getters and setters for the values we want to change. 

The only existing API I couldn't support was [withYamlReplacement](https://github.com/jancona/farsandra/blob/5c65a9a21e657097e32be0f750637a43f174828b/farsandra-core/src/main/java/io/teknek/farsandra/Farsandra.java#L116). I could do something like `withYamlReplacement(String name, Object Value)` but it wouldn't be compatible with the existing API.
